### PR TITLE
added-webhook-guide

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -207,7 +207,7 @@
         },
         {
           "group": "Cable & Bill Payments",
-          "icon": "money-bill",
+          "icon": "tv",
           "pages": [
             {
               "group": "Cable TV",
@@ -244,7 +244,8 @@
         "support/guides/accept-online-payments",
         "support/guides/authentication-best-practises",
         "support/guides/setting-up-webhooks",
-        "support/guides/processing-recurring-payments"
+        "support/guides/processing-recurring-payments",
+        "support/guides/add-shopify-webhook-url"
       ]
     },
     {
@@ -381,7 +382,7 @@
   ],
   "footer": {
     "socials": {
-     "twitter": "https://twitter.com/nombahq",
+    "twitter": "https://twitter.com/nombahq",
     "github": "https://github.com/kudi-inc",
     "linkedin": "https://www.linkedin.com/company/nombahq"
     },

--- a/plugins-and-sdk/overview.mdx
+++ b/plugins-and-sdk/overview.mdx
@@ -41,6 +41,8 @@ Our plugins offer a quick way to integrate Nomba payments into popular e-commerc
   </Card>
 </CardGroup>
 
+To Explore how you can add webhook to Nomba Dashboard for shopify, Please follow this [guide](support/guides/add-shopify-webhook-url).
+
 ## SDKs
 Our SDKs allow you to build seamless payment experiences directly into your mobile or web applications. Choose the SDK that best fits your development stack:
 

--- a/support/guides/add-shopify-webhook-url.mdx
+++ b/support/guides/add-shopify-webhook-url.mdx
@@ -29,15 +29,15 @@ This guide will walk you through the steps to add your Shopify webhook URL to th
 
 ## Step 2: Monitor and Manage Webhooks
 
-- You can view, edit, or delete webhooks from the Shopify **Notifications** settings.
-- Ensure your webhook URL remains active and secure.
+1. You can view, edit, or delete webhooks from the Shopify **Notifications** settings.
+2. Ensure your webhook URL remains active and secure.
 
 ---
 
 ## Troubleshooting
 
-- **Webhook not triggering:** Ensure the event type matches your use case and the URL is correct.
-- **No response in Nomba:** Check your Nomba dashboard for errors or contact Nomba support.
+1. **Webhook not triggering:** Ensure the event type matches your use case and the URL is correct.
+2. **No response in Nomba:** Check your Nomba dashboard for errors or contact Nomba support.
 
 ---
 

--- a/support/guides/add-shopify-webhook-url.mdx
+++ b/support/guides/add-shopify-webhook-url.mdx
@@ -1,0 +1,44 @@
+# How to Add a Shopify Webhook URL on the Nomba Dashboard
+
+This guide will walk you through the steps to add your Shopify webhook URL to the Nomba dashboard, enabling seamless integration between your Shopify store and Nomba services.
+
+---
+
+## Prerequisites
+
+1. Access to your Shopify admin dashboard.
+2. Access to your Nomba dashboard.
+3. Nomba valid webhook URL
+
+---
+
+---
+
+## Step 1: Add the Webhook URL to Nomba Dashboard
+
+1. Log in to your [Nomba dashboard](https://dashboard.nomba.com/auth/login/).
+2. In the left sidebar, click on **Settings**.
+3. Select **Webhook and APIkeys** from the settings tab.
+4. Scroll down to the **Webhooks** section.
+5. Click **Create webhook**.
+6. Paste this webhook url: https://shopcheckout.nomba.com/app/payment_webhooks
+7. In the **Event** dropdown, select the event you want to listen for (e.g., "payment success").
+8. Click **Subscribe**.
+
+---
+
+## Step 2: Monitor and Manage Webhooks
+
+- You can view, edit, or delete webhooks from the Shopify **Notifications** settings.
+- Ensure your webhook URL remains active and secure.
+
+---
+
+## Troubleshooting
+
+- **Webhook not triggering:** Ensure the event type matches your use case and the URL is correct.
+- **No response in Nomba:** Check your Nomba dashboard for errors or contact Nomba support.
+
+---
+
+By following these steps, you can successfully integrate Shopify webhooks with your Nomba dashboard for real-time event notifications.


### PR DESCRIPTION
This PR added a guide to help readers understand how they can add a Shopify webhook to the Nomba dashboard, Subscribe for events and manage events. 