### PR TITLE
update/rename title definations for account

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -97,8 +97,8 @@
           "icon": "building-columns",
           "pages": [
             "products/accounts/introduction",
-            "products/accounts/creating-a-virtual-account",
-            "products/accounts/fetching-account-balance",
+            "products/accounts/fetch-account-balance",
+            "products/accounts/create-a-virtual-account",
             "products/accounts/suspension-and-reactivation",
             "products/accounts/perform-virtual-account-lookup"
           ]

--- a/nomba-api-changelog/api/updates.mdx
+++ b/nomba-api-changelog/api/updates.mdx
@@ -22,9 +22,8 @@ icon: pen-nib
 
 • **Webhook payment success** `updated` – We have made some changes to the webhook `payment_success` payload , click here to learn more about it. [View Changes](/products/webhooks/introduction).
 
-
 ### April 2025
-• **Signature verification** `docs` –  Updated the documentation structure for improved readability when working with webhook signature verification. Also added a new `PHP` code sample. [view the updates](/products/webhooks/signature-verification-new).
+• **Signature verification** `docs` –  we have updated the documentation structure to improve readability when working with webhook signature verification. we have also added a new `PHP` code sample. [view the updates](/products/webhooks/signature-verification-new).
 
 • **Transaction Requery Title Fix** `docs` – Fixed a title mismatch and clarified the content on the transaction requery page. check [this page](/nomba-api-reference/transactions/transaction-requery) to see the updates.
 
@@ -32,11 +31,11 @@ icon: pen-nib
 
 • **Flutter SDKs** `added` – Added documentation for the Flutter SDK [View SDK](/plugins-and-sdk/overview#sdks).
 
-• **Fetch CableTv Plan** `added` – Added documentation for fetching cable Tv based on type. [Click to learn more](/products/bills/fetch-cable-tv-plans).
+• **Fetch CableTv Plan** `added` – We have added documentation for fetching cable Tv based on cable Tv type. [Click to learn more](/products/bills/fetch-cable-tv-plans).
 
 ### March 2025
 
-• **Webhook Re-push** `added` – Added documentation for the Webhook Re-push API. [Learn more](/products/webhooks/repush).
+• **Webhook Re-push** `added` –  We have added documentation for the Webhook Re-push API. [Learn more](/products/webhooks/repush).
 
 ### February 2025
 

--- a/products/accounts/create-a-virtual-account.mdx
+++ b/products/accounts/create-a-virtual-account.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Creating virtual accounts"
+title: "Create virtual accounts"
 description: "Learn about creating virtual accounts"
 ---
 

--- a/products/accounts/fetch-account-balance.mdx
+++ b/products/accounts/fetch-account-balance.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Fetching account balance'
+title: 'Fetch parent account balance'
 description: 'Learn about fetching account balances'
 ---
 

--- a/products/accounts/suspension-and-reactivation.mdx
+++ b/products/accounts/suspension-and-reactivation.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Suspending accounts'
+title: 'Suspend virtual accounts'
 description: 'Learn about suspending an accounts'
 ---
 

--- a/products/terminals/assigning-terminals.mdx
+++ b/products/terminals/assigning-terminals.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Assigning terminals'
+title: 'Assign terminals'
 description: 'Learn how to assign terminals to accounts'
 ---
 

--- a/products/terminals/unassigning-terminals.mdx
+++ b/products/terminals/unassigning-terminals.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Unassigning terminals'
+title: 'Unassign terminals'
 description: 'Learn how to unassign terminals from accounts'
 ---
 


### PR DESCRIPTION
This PR contains update on renaming the account sub section titles to focus an action rather than process.

For example: creating virtual accounts has been renamed to create virtual acounts 

Suspending virtual account -----> suspend virtual accounts

Fetching parent account balance ----> fetch parent account balance

I have change some passive words to active word to improve clarity in changelog 