### PR TITLE
docs: global payout — add Brails African corridors (SA bank, UAE bank, mobile money)

### DIFF
--- a/docs/products/global-payout/authorize-transfer.mdx
+++ b/docs/products/global-payout/authorize-transfer.mdx
@@ -25,6 +25,7 @@ The `paymentMethod` field determines which additional fields are required:
 | `paymentMethod` | Required fields | Optional fields |
 |---|---|---|
 | `BANK` (non-Canada, e.g. DRC) | `accountNumber`, `receiverName`, `institutionName` (bank display name), `institutionCode` (bank code from `/bank/providers`) | `narration` |
+| `BANK` (South Africa) | `accountNumber`, `receiverName`, `institutionCode` (bank code from `/bank/providers`), `institutionName`, `purposeOfPayment`, `beneficiary.beneficiaryAddress`, `beneficiary.beneficiaryCity`, `beneficiary.beneficiaryPostCode` | `accountType` (`Individual` or `Corporate`), `beneficiary.beneficiaryState`, `beneficiary.dateOfBirth` (Individual), `beneficiary.countryOfBirth` (Individual), `beneficiary.registrationNumber` (Corporate) |
 | `BANK` (Canada) | `accountNumber`, `receiverName`, `institutionCode` (institution number), `beneficiary.beneficiaryEmail` | `beneficiary.securityQuestion`, `beneficiary.securityQuestionAnswer`, `beneficiary.transitNumber`, `narration` |
 | `MobileMoney` | `accountNumber` (recipient phone number), `receiverName`, `institutionName` (provider display name) | `narration` |
 | `INTERAC` | `receiverName`, `beneficiary.beneficiaryEmail` | `beneficiary.securityQuestion`, `beneficiary.securityQuestionAnswer` |
@@ -169,6 +170,37 @@ curl --request POST \
   }'
 ```
 
+```bash BANK (South Africa — Individual)
+curl --request POST \
+  --url https://api.nomba.com/v1/global-payout/transfer/authorize \
+  --header 'Authorization: Bearer <token>' \
+  --header 'Content-Type: application/json' \
+  --header 'accountId: <accountId>' \
+  --data '{
+    "amount": 500.0,
+    "sourceCurrency": "USD",
+    "destinationCurrency": "ZAR",
+    "accountNumber": "1234567890",
+    "receiverName": "Jane Doe",
+    "institutionCode": "2763",
+    "institutionName": "Standard Bank",
+    "sourceCountryIsoCode": "NG",
+    "destinationCountryIsoCode": "ZA",
+    "authCode": "2580",
+    "paymentMethod": "Bank",
+    "accountType": "Individual",
+    "purposeOfPayment": "FAMILY_SUPPORT",
+    "beneficiary": {
+      "beneficiaryAddress": "123 Main Street",
+      "beneficiaryCity": "Cape Town",
+      "beneficiaryPostCode": "8001",
+      "beneficiaryState": "Western Cape",
+      "dateOfBirth": "1985-03-15",
+      "countryOfBirth": "ZA"
+    }
+  }'
+```
+
 ```bash SEPA (Europe)
 curl --request POST \
   --url https://api.nomba.com/v1/global-payout/transfer/authorize \
@@ -232,7 +264,7 @@ curl --request POST \
 </CodeGroup>
 
 <Note>
-  The `MobileMoney (Africa)` payload shape also applies to South Africa (`ZA`/`ZAR`), Ghana (`GH`/`GHS`), Senegal (`SN`/`XOF`), and Tanzania (`TZ`/`TZS`). Swap the destination country code, destination currency, account number, and provider `institutionName` for the recipient's market.
+  The `MobileMoney (Africa)` payload shape applies to all African mobile money corridors. Swap the destination country code, destination currency, account number, and provider `institutionName` for the recipient's market. Supported countries: Ghana (`GH`/`GHS`), Kenya (`KE`/`KES`), Senegal (`SN`/`XOF`), Ethiopia (`ET`/`ETB`), Rwanda (`RW`/`RWF`), Uganda (`UG`/`UGX`), Cameroon (`CM`/`XAF`), Gabon (`GA`/`XAF`), Côte d'Ivoire (`CI`/`XOF`). Call [List Institution Providers](/docs/products/global-payout/mobile-money-providers) with `countryIsoCode` set to the destination country to get valid provider codes.
 </Note>
 
 <Tip>
@@ -302,10 +334,10 @@ curl --request POST \
 </ParamField>
 
 <ParamField body="beneficiary" type="object">
-  Beneficiary details. Required for `INTERAC`; partially required for `BANK` (Canada).
+  Beneficiary details. Required for `INTERAC`; partially required for `BANK` (Canada and South Africa).
   <Expandable title="object">
     <ParamField body="beneficiaryEmail" type="string">
-      Recipient email address.
+      Recipient email address. Required for `INTERAC` and `BANK` (Canada).
     </ParamField>
     <ParamField body="securityQuestion" type="string">
       Security question for Interac e-Transfer.
@@ -315,6 +347,27 @@ curl --request POST \
     </ParamField>
     <ParamField body="transitNumber" type="string">
       Bank transit number (Canada only).
+    </ParamField>
+    <ParamField body="beneficiaryAddress" type="string">
+      Recipient street address. Required for South Africa.
+    </ParamField>
+    <ParamField body="beneficiaryCity" type="string">
+      Recipient city. Required for South Africa.
+    </ParamField>
+    <ParamField body="beneficiaryPostCode" type="string">
+      Recipient postal code. Required for South Africa.
+    </ParamField>
+    <ParamField body="beneficiaryState" type="string">
+      Recipient state or province. Optional.
+    </ParamField>
+    <ParamField body="dateOfBirth" type="string">
+      Recipient date of birth in `YYYY-MM-DD` format (e.g., `1985-03-15`). Required for South Africa when `accountType` is `Individual`.
+    </ParamField>
+    <ParamField body="countryOfBirth" type="string">
+      Recipient country of birth as an ISO 3166-1 alpha-2 code (e.g., `ZA`). Required for South Africa when `accountType` is `Individual`.
+    </ParamField>
+    <ParamField body="registrationNumber" type="string">
+      Business registration number. Required for South Africa when `accountType` is `Corporate`.
     </ParamField>
   </Expandable>
 </ParamField>

--- a/docs/products/global-payout/introduction.mdx
+++ b/docs/products/global-payout/introduction.mdx
@@ -48,7 +48,7 @@ GlobalPayout enables cross-border fund disbursements, giving you full control ov
     icon="building-columns"
     href="/docs/products/global-payout/mobile-money-providers"
   >
-    Retrieve available banks and mobile money providers for DRC transfers.
+    Retrieve available banks and mobile money providers for your destination country.
   </Card>
 </CardGroup>
 

--- a/docs/products/global-payout/mobile-money-providers.mdx
+++ b/docs/products/global-payout/mobile-money-providers.mdx
@@ -22,6 +22,10 @@ Use the `code` from the response as `institutionCode` and `displayName` as `inst
   `false` (default) returns bank providers. `true` returns mobile money providers.
 </ParamField>
 
+<ParamField query="countryIsoCode" type="string">
+  ISO 3166-1 alpha-2 destination country code (e.g., `KE`, `ZA`, `GH`, `ET`, `RW`). When provided, takes priority over the region derived from your JWT. Use this when your platform supports multiple destination countries — pass the recipient's country code to get the correct provider list.
+</ParamField>
+
 <CodeGroup>
 ```bash Banks (isMobileMoney=false)
 curl --request GET \
@@ -69,8 +73,29 @@ curl --request GET \
 </CodeGroup>
 
 <Tip>
-  This endpoint returns providers for all supported mobile money countries, including DRC, Kenya, South Africa, Ghana, Senegal, and Tanzania. Use `isMobileMoney=true` for mobile money providers and pass the relevant destination country ISO code as a query parameter when filtering providers by destination. `code` from this endpoint → `institutionCode` in the transfer request. `displayName` → `institutionName`.
+  Always pass `countryIsoCode` when calling this endpoint. Multiple countries share the same currency (e.g., XOF covers Senegal and Côte d'Ivoire; XAF covers Cameroon and Gabon) — the country code is how the API returns the correct provider list for your destination. `code` from this endpoint → `institutionCode` in the transfer request. `displayName` → `institutionName`.
 </Tip>
+
+## Providers by Country
+
+| Country | ISO Code | Currency | Mobile Money Providers |
+|---|---|---|---|
+| DR Congo | CD | USD / CDF | Nomba, Airtel Money, M-Pesa, Orange |
+| Kenya | KE | KES | M-Pesa |
+| Ghana | GH | GHS | MTN Mobile Money |
+| South Africa | ZA | ZAR | Bank only — use `isMobileMoney=false` |
+| Senegal | SN | XOF | Orange Money, Wave |
+| Côte d'Ivoire | CI | XOF | Orange Money, MTN, Moov, Wave |
+| Ethiopia | ET | ETB | Safaricom M-Pesa, Ethio Telecom |
+| Rwanda | RW | RWF | MTN Mobile Money, Airtel Money |
+| Uganda | UG | UGX | MTN Mobile Money, Airtel Money |
+| Cameroon | CM | XAF | MTN Mobile Money, Orange Money |
+| Gabon | GA | XAF | Airtel Money, Moov |
+| UAE | AE | AED | Bank only — use `isMobileMoney=false` |
+
+<Note>
+  Provider codes (`institutionCode`) and display names (`institutionName`) returned by this endpoint are the canonical values — always call the API rather than hardcoding them, as they may be updated.
+</Note>
 
 #### Response body
 

--- a/docs/products/global-payout/supported-countries.mdx
+++ b/docs/products/global-payout/supported-countries.mdx
@@ -17,11 +17,17 @@ Global Payout supports cross-border fund disbursements to a growing list of coun
 | Democratic Republic of Congo | USD | Bank | $1 | $50,000 | Same day, subject to cut-off at 5pm (UTC +1) |
 | Democratic Republic of Congo | CDF | Mobile Money | FC 1 | FC 7,500,000 | Instant |
 | Democratic Republic of Congo | CDF | Bank | FC 3,000 | FC 22,768,634 | Same day, subject to cut-off at 5pm (UTC +1) |
+| United Arab Emirates | AED | Bank | AED 1 | AED 100,000 | Instant |
 | South Africa | ZAR | Bank | ZAR 20 | ZAR 1,800,000 | Instant |
 | Ghana | GHS | Mobile Money | GHS 20 | GHS 15,000 | Instant |
 | Kenya | KES | Mobile Money | KES 20 | KES 250,000 | Instant |
 | Senegal | XOF | Mobile Money | XOF 100 | XOF 200,000 | Instant |
-| Tanzania | TZS | Mobile Money | TZS 100 | TZS 3,000,000 | Instant |
+| Côte d'Ivoire | XOF | Mobile Money | XOF 100 | XOF 500,000 | Instant |
+| Ethiopia | ETB | Mobile Money | ETB 10 | ETB 50,000 | Instant |
+| Rwanda | RWF | Mobile Money | RWF 100 | RWF 500,000 | Instant |
+| Uganda | UGX | Mobile Money | UGX 500 | UGX 5,000,000 | Instant |
+| Cameroon | XAF | Mobile Money | XAF 100 | XAF 500,000 | Instant |
+| Gabon | XAF | Mobile Money | XAF 100 | XAF 500,000 | Instant |
 | Canada | CAD | Bank | $1 | $25,000 | Processed within 1 to 3 business days |
 | Canada | CAD | Interac | $1 | $25,000 | Instant |
 | United Kingdom | GBP | Faster Payments | £1 | £1,000,000 | Processed within 1 to 3 hours |

--- a/docs/products/global-payout/supported-currencies.mdx
+++ b/docs/products/global-payout/supported-currencies.mdx
@@ -18,11 +18,16 @@ Global Payout supports cross-border fund disbursements across a range of currenc
 | Canadian Dollar | CAD | Destination |
 | British Pound | GBP | Destination |
 | Euro | EUR | Destination |
+| UAE Dirham | AED | Destination |
 | South African Rand | ZAR | Destination |
 | Ghanaian Cedi | GHS | Destination |
 | Kenyan Shilling | KES | Destination |
 | West African CFA Franc | XOF | Destination |
+| Central African CFA Franc | XAF | Destination |
 | Tanzanian Shilling | TZS | Destination |
+| Ethiopian Birr | ETB | Destination |
+| Rwandan Franc | RWF | Destination |
+| Ugandan Shilling | UGX | Destination |
 
 ## Using Exchange Rates
 


### PR DESCRIPTION
## Summary
- Adds new Global Payout destination currencies and corridor rows for Brails-supported markets.
- Documents `countryIsoCode` for provider lookup and adds a providers-by-country reference table.
- Adds the South Africa bank authorization example and beneficiary field documentation.
- Updates the Global Payout introduction card copy for provider lookup.

## Verification
- Confirmed `git diff main` is limited to the five intended Global Payout MDX files.
- Ran `git diff --check main` successfully.
- Ran `npx mintlify validate` successfully.
- Manually reviewed changed MDX tables, Mintlify components, and code fences for malformed syntax.

## Notes before publish
- Ops should confirm placeholder limits for ETB, RWF, UGX, and XAF corridors.