### PR TITLE
docs(airtime-and-data): make productId the required data purchase selector

### DIFF
--- a/docs/products/airtime-and-data/buy-data-bundle.mdx
+++ b/docs/products/airtime-and-data/buy-data-bundle.mdx
@@ -13,6 +13,10 @@ description: "How to Buy Data Bundle using this API"
 
 To successfully buy a data bundle using our endpoints, it is necessary to undergo the following steps:
 
-1. Fetch Available data plans (this returns a list of available data plans)
+1. Fetch available data plans — this returns a list of available data plans, each with a `productId`.
 
-2. Then, Buy Data Bundle
+2. Buy the data bundle, passing the `productId` of the plan you want in the purchase request. `productId` is required.
+
+<Note>
+  Purchasing by `amount` alone is deprecated and only still works for merchants already integrated against it. All new integrations must select a plan from step 1 and pass its `productId` — this is the only reliable way to get the exact bundle you intended, since more than one plan on the same network can share the same price.
+</Note>

--- a/docs/products/airtime-and-data/fetch-data-plans.mdx
+++ b/docs/products/airtime-and-data/fetch-data-plans.mdx
@@ -17,55 +17,68 @@ curl --location 'https://api.nomba.com/v1/bill/data-plan/<telco>' \
     "data": [
         {
             "plan": "20MB -> 1Day (N50)",
-            "amount": 50
+            "amount": 50,
+            "productId": "glo1"
         },
         {
             "plan": "75MB -> 1Day (N100)",
-            "amount": 100
+            "amount": 100,
+            "productId": "glo2"
         },
         {
             "plan": "200MB -> 3Days (N200)",
-            "amount": 200
+            "amount": 200,
+            "productId": "glo3"
         },
         {
             "plan": "350MB -> 7Days (N300)",
-            "amount": 300
+            "amount": 300,
+            "productId": "glo4"
         },
         {
             "plan": "750MB -> 14Days (N500)",
-            "amount": 500
+            "amount": 500,
+            "productId": "glo5"
         },
         {
             "plan": "1.5GB -> 30Days (N1,000)",
-            "amount": 1000
+            "amount": 1000,
+            "productId": "glo6"
         },
         {
             "plan": "3.5GB -> 30Days (N1,500)",
-            "amount": 1500
+            "amount": 1500,
+            "productId": "glo7"
         },
         {
             "plan": "5.5GB -> 30Days (N2,500)",
-            "amount": 2500
+            "amount": 2500,
+            "productId": "glo8"
         },
         {
             "plan": "6.5GB -> 30Days (N3,000)",
-            "amount": 3000
+            "amount": 3000,
+            "productId": "glo9"
         },
         {
             "plan": "9.5GB -> 30Days (N4,000)",
-            "amount": 4000
+            "amount": 4000,
+            "productId": "glo10"
         },
         {
             "plan": "12GB -> 30Days (N5,000)",
-            "amount": 5000
+            "amount": 5000,
+            "productId": "glo11"
         },
         {
             "plan": "25GB -> 30Days (N10,000)",
-            "amount": 10000
+            "amount": 10000,
+            "productId": "glo12"
         },
         {
             "plan": "40GB -> 30Days (N15,000)",
-            "amount": 15000
+            "amount": 15000,
+            "productId": "glo13"
         }
     ],
     "description": "Successful",
@@ -99,6 +112,9 @@ List of available data plans for the telco supplied
     </ResponseField>
     <ResponseField name="plan" type="string" required>
       Plan name
+    </ResponseField>
+    <ResponseField name="productId" type="string" required>
+      The unique identifier for this data plan. Pass this value as `productId` in the [Buy Data Bundle](/nomba-api-reference/airtime-and-data-vending/vend-data-bundles-via-parent-account) request to purchase this exact bundle.
     </ResponseField>
   </Expandable>
 </ResponseField>

--- a/docs/products/airtime-and-data/fetch-data-plans.mdx
+++ b/docs/products/airtime-and-data/fetch-data-plans.mdx
@@ -12,73 +12,73 @@ curl --location 'https://api.nomba.com/v1/bill/data-plan/<telco>' \
 --header 'Authorization: Bearer <token>'
 ```
 
-```json Response
+```json Example Response
 {
     "data": [
         {
             "plan": "20MB -> 1Day (N50)",
             "amount": 50,
-            "productId": "glo1"
+            "productId": "example-plan-id-1"
         },
         {
             "plan": "75MB -> 1Day (N100)",
             "amount": 100,
-            "productId": "glo2"
+            "productId": "example-plan-id-2"
         },
         {
             "plan": "200MB -> 3Days (N200)",
             "amount": 200,
-            "productId": "glo3"
+            "productId": "example-plan-id-3"
         },
         {
             "plan": "350MB -> 7Days (N300)",
             "amount": 300,
-            "productId": "glo4"
+            "productId": "example-plan-id-4"
         },
         {
             "plan": "750MB -> 14Days (N500)",
             "amount": 500,
-            "productId": "glo5"
+            "productId": "example-plan-id-5"
         },
         {
             "plan": "1.5GB -> 30Days (N1,000)",
             "amount": 1000,
-            "productId": "glo6"
+            "productId": "example-plan-id-6"
         },
         {
             "plan": "3.5GB -> 30Days (N1,500)",
             "amount": 1500,
-            "productId": "glo7"
+            "productId": "example-plan-id-7"
         },
         {
             "plan": "5.5GB -> 30Days (N2,500)",
             "amount": 2500,
-            "productId": "glo8"
+            "productId": "example-plan-id-8"
         },
         {
             "plan": "6.5GB -> 30Days (N3,000)",
             "amount": 3000,
-            "productId": "glo9"
+            "productId": "example-plan-id-9"
         },
         {
             "plan": "9.5GB -> 30Days (N4,000)",
             "amount": 4000,
-            "productId": "glo10"
+            "productId": "example-plan-id-10"
         },
         {
             "plan": "12GB -> 30Days (N5,000)",
             "amount": 5000,
-            "productId": "glo11"
+            "productId": "example-plan-id-11"
         },
         {
             "plan": "25GB -> 30Days (N10,000)",
             "amount": 10000,
-            "productId": "glo12"
+            "productId": "example-plan-id-12"
         },
         {
             "plan": "40GB -> 30Days (N15,000)",
             "amount": 15000,
-            "productId": "glo13"
+            "productId": "example-plan-id-13"
         }
     ],
     "description": "Successful",
@@ -86,6 +86,10 @@ curl --location 'https://api.nomba.com/v1/bill/data-plan/<telco>' \
 }
 ```
 </CodeGroup>
+
+<Warning>
+  The plans, amounts, and `productId`s above are **illustrative only** — they do not represent real, current plans. This catalog can change at any time (and today is not the same source of truth used internally, so it may drift further as that changes). Never hardcode plan data from this example: always call this endpoint live and use the `productId` it returns in your purchase request.
+</Warning>
 
 #### Path parameters
 

--- a/nomba-api-changelog/api/updates.mdx
+++ b/nomba-api-changelog/api/updates.mdx
@@ -7,6 +7,9 @@ icon: pen-nib
 <Note>
    We are constantly making changes to the Nomba API. We recommend reviewing this changelog to stay updated on what’s new, improved, or deprecated. This ensures you remain aligned with our product.
 </Note>
+### July 2026
+- **Buy Data Bundle** `updated` – Added a new `productId` field to [Fetch Data Plans](/docs/products/airtime-and-data/fetch-data-plans) and [Buy Data Bundle](/nomba-api-reference/airtime-and-data-vending/vend-data-bundles-via-parent-account). Use the `productId` returned by Fetch Data Plans to select an exact bundle when purchasing — this removes ambiguity when multiple plans on the same network share the same price. Purchasing by `amount` alone is now **deprecated** and kept only for backward compatibility; new integrations should always use `productId`. The purchase response now also includes `productId` and `plan`, so you can confirm exactly which bundle was vended.
+
 ### April 2026
 - [Transfer](/docs/products/transfers/transfer-to-banks) `docs` – We have added a detailed explanation of how transfers work.
 

--- a/nomba-api-reference/openapi.json
+++ b/nomba-api-reference/openapi.json
@@ -14852,11 +14852,17 @@
       "DataVendingRequest": {
         "type": "object",
         "properties": {
+          "productId": {
+            "type": "string",
+            "description": "The unique identifier of the data plan to purchase — returned as `productId` by the Fetch Data Plans endpoint. Required for all new integrations: it resolves to an exact plan and amount, removing any ambiguity when multiple plans on the same network share the same price.",
+            "example": "mtn47"
+          },
           "amount": {
             "type": "number",
             "format": "double",
-            "description": "The data amount to be vended",
-            "example": 200
+            "description": "**Deprecated — do not use for new integrations.** The data plan amount. This field is retained only so existing merchants already integrated against it continue to work; new integrations must use `productId` instead. When `amount` is supplied without `productId`, it is matched against our supported plans and rejected if it doesn't match one — and since more than one plan can share the same price, it cannot reliably select a specific bundle.",
+            "example": 200,
+            "deprecated": true
           },
           "phoneNumber": {
             "type": "string",
@@ -14889,7 +14895,7 @@
           }
         },
         "required": [
-          "amount",
+          "productId",
           "phoneNumber",
           "network",
           "merchantTxRef"
@@ -14901,8 +14907,18 @@
           "amount": {
             "type": "number",
             "format": "double",
-            "description": "The airtime amount to be purchased",
+            "description": "The amount charged for this data purchase.",
             "example": 200
+          },
+          "productId": {
+            "type": "string",
+            "description": "The identifier of the data plan that was vended.",
+            "example": "mtn47"
+          },
+          "plan": {
+            "type": "string",
+            "description": "A human-readable description of the exact data bundle that was vended (size and validity).",
+            "example": "3.5GB Daily Plan"
           },
           "timeCreated": {
             "type": "string",
@@ -17922,6 +17938,11 @@
           "plan": {
             "type": "string",
             "example": "40GB -> 30Days (N15,000)"
+          },
+          "productId": {
+            "type": "string",
+            "description": "The unique identifier for this data plan. Pass this value as `productId` when purchasing to select this exact bundle.",
+            "example": "mtn47"
           }
         }
       },

--- a/nomba-api-reference/openapi.json
+++ b/nomba-api-reference/openapi.json
@@ -14874,7 +14874,7 @@
           "amount": {
             "type": "number",
             "format": "double",
-            "description": "**Deprecated — do not use for new integrations.** The data plan amount. This field is retained only so existing merchants already integrated against it continue to work; new integrations must use `productId` instead. When `amount` is supplied without `productId`, it is matched against our supported plans and rejected if it doesn't match one — and since more than one plan can share the same price, it cannot reliably select a specific bundle.",
+            "description": "**Deprecated — do not use.** `amount` is a legacy-only field with no guarantee of correctness: multiple plans can share the same price, so it cannot reliably identify the bundle you want. Use `productId` — the only supported way to select a plan.",
             "deprecated": true
           },
           "phoneNumber": {

--- a/nomba-api-reference/openapi.json
+++ b/nomba-api-reference/openapi.json
@@ -10347,6 +10347,13 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DataVendingRequest"
+              },
+              "example": {
+                "productId": "mtn47",
+                "phoneNumber": "08055441122",
+                "network": "GLO",
+                "merchantTxRef": "3bvwhibh38220dsjakTwvb",
+                "senderName": "John Doe"
               }
             }
           },
@@ -10511,6 +10518,13 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/DataVendingRequest"
+              },
+              "example": {
+                "productId": "mtn47",
+                "phoneNumber": "08055441122",
+                "network": "GLO",
+                "merchantTxRef": "3bvwhibh38220dsjakTwvb",
+                "senderName": "John Doe"
               }
             }
           },
@@ -14861,7 +14875,6 @@
             "type": "number",
             "format": "double",
             "description": "**Deprecated — do not use for new integrations.** The data plan amount. This field is retained only so existing merchants already integrated against it continue to work; new integrations must use `productId` instead. When `amount` is supplied without `productId`, it is matched against our supported plans and rejected if it doesn't match one — and since more than one plan can share the same price, it cannot reliably select a specific bundle.",
-            "example": 200,
             "deprecated": true
           },
           "phoneNumber": {


### PR DESCRIPTION
## What & why

VendorAPI's `POST /v1/bill/data` (Buy Data Bundle) no longer selects a data plan by amount alone — a `productId` field now resolves the exact bundle. This was needed because more than one plan on the same network can share the same price, so `amount` alone couldn't reliably identify which bundle a merchant wanted.

## What changed in the docs

- **Buy Data Bundle request** (`openapi.json` → `DataVendingRequest`): added `productId` as a required field. `amount` is now documented as **deprecated** — kept only so merchants already integrated against it keep working; new integrations must use `productId`.
- **Buy Data Bundle response** (`openapi.json` → `DataVendingResponse`): added `productId` and `plan` so callers can see exactly which bundle was vended, not just the amount/network they sent. Also fixed a pre-existing copy-paste bug where the response's `amount` field was described as "The airtime amount to be purchased" on the *data* schema.
- **Fetch Data Plans response** (`openapi.json` → `DataPlanList`, and the separate hand-written example on `docs/products/airtime-and-data/fetch-data-plans.mdx`): added `productId` to each returned plan.
- **Buy Data Bundle overview** (`docs/products/airtime-and-data/buy-data-bundle.mdx`): updated the two-step flow description to show `productId` flowing from step 1 (fetch plans) into step 2 (purchase), with a note on the `amount` deprecation.
- **Changelog**: new July 2026 entry.

## Note

`productId` is documented as required to steer all new integrations toward it. The live API still accepts `amount`-only requests for backward compatibility — that's intentional and only reflected in the deprecation note, not enforced in the docs' required-fields list, so it doesn't imply new integrations should rely on it.
