### PR TITLE
fix(transfers): correct fetch-banks response shape to match live API

### DIFF
--- a/docs/products/transfers/fetch-bank-codes-and-names.mdx
+++ b/docs/products/transfers/fetch-bank-codes-and-names.mdx
@@ -35,10 +35,10 @@ const response = await fetch('https://api.nomba.com/v1/transfers/banks', {
 const { code, data } = await response.json();
 if (code !== '00') throw new Error('Failed to fetch bank codes');
 
-const banks = data.results;
+const banks = data;
 // Example: find GTBank
-const gtbank = banks.find(b => b.name.includes('Guaranty Trust'));
-console.log(gtbank); // { code: '058', name: 'Guaranty Trust Bank' }
+const gtbank = banks.find(b => b.code === '058');
+console.log(gtbank); // { name: 'GTBank', code: '058', nipCode: null, logo: 'https://...' }
 ```
 
 ```python Python
@@ -56,7 +56,7 @@ result = response.json()
 if result['code'] != '00':
     raise Exception('Failed to fetch bank codes')
 
-banks = result['data']['results']
+banks = result['data']
 # Example: build a lookup dict
 bank_map = {b['name']: b['code'] for b in banks}
 ```
@@ -64,27 +64,35 @@ bank_map = {b['name']: b['code'] for b in banks}
 ```json Response
 {
   "code": "00",
-  "description": "Success",
-  "data": {
-    "results": [
-      {
-        "code": "058",
-        "name": "Guaranty Trust Bank"
-      },
-      {
-        "code": "011",
-        "name": "First Bank of Nigeria"
-      },
-      {
-        "code": "033",
-        "name": "United Bank for Africa"
-      },
-      {
-        "code": "090160",
-        "name": "Addosser Microfinance Bank"
-      }
-    ]
-  }
+  "description": "SUCCESS",
+  "message": "SUCCESS",
+  "status": true,
+  "data": [
+    {
+      "name": "GTBank",
+      "code": "058",
+      "nipCode": null,
+      "logo": "https://firebasestorage.googleapis.com/v0/b/business-banking-93cc1.appspot.com/o/bankLogos%2FGroup%209.png?alt=media&token=98bde9e8-1862-495d-9046-bd3d96465970"
+    },
+    {
+      "name": "First Bank of Nigeria",
+      "code": "011",
+      "nipCode": null,
+      "logo": "https://firebasestorage.googleapis.com/v0/b/business-banking-93cc1.appspot.com/o/bankLogos%2FGroup%201.png?alt=media&token=06a3a300-dafe-49db-b3d3-049371bf1173"
+    },
+    {
+      "name": "United Bank for Africa",
+      "code": "033",
+      "nipCode": null,
+      "logo": "https://firebasestorage.googleapis.com/v0/b/business-banking-93cc1.appspot.com/o/bankLogos%2FGroup%2025.png?alt=media&token=a2a144de-9c8b-4811-8278-7666746486ee"
+    },
+    {
+      "name": "Addosser Microfinance Bank",
+      "code": "090160",
+      "nipCode": null,
+      "logo": ""
+    }
+  ]
 }
 ```
 </CodeGroup>
@@ -99,16 +107,20 @@ bank_map = {b['name']: b['code'] for b in banks}
   Response description.
 </ResponseField>
 
-<ResponseField name="data" type="object">
-    <ResponseField name="results" type="object[]">
-        List of all supported banks.
-        <Expandable title="object" defaultOpen="true">
-            <ResponseField name="code" type="string">
-                The bank's code. Use this as `bankCode` in transfer and lookup requests.
-            </ResponseField>
-            <ResponseField name="name" type="string">
-                The bank's display name.
-            </ResponseField>
-        </Expandable>
-    </ResponseField>
+<ResponseField name="data" type="object[]">
+    List of all supported banks.
+    <Expandable title="object" defaultOpen="true">
+        <ResponseField name="code" type="string">
+            The bank's code. Use this as `bankCode` in transfer and lookup requests.
+        </ResponseField>
+        <ResponseField name="name" type="string">
+            The bank's display name.
+        </ResponseField>
+        <ResponseField name="nipCode" type="string | null">
+            The bank's NIP institution code. May be `null`.
+        </ResponseField>
+        <ResponseField name="logo" type="string">
+            URL of the bank's logo image. An empty string when no logo is available.
+        </ResponseField>
+    </Expandable>
 </ResponseField>

--- a/nomba-api-reference/openapi.json
+++ b/nomba-api-reference/openapi.json
@@ -6297,11 +6297,15 @@
                     },
                     "description": {
                       "type": "string",
-                      "example": "Success",
+                      "example": "SUCCESS",
                       "description": "Response description"
                     },
                     "data": {
-                      "$ref": "#/components/schemas/BanksListResults"
+                      "type": "array",
+                      "description": "List of all supported banks",
+                      "items": {
+                        "$ref": "#/components/schemas/Banks"
+                      }
                     }
                   },
                   "required": [
@@ -16218,19 +16222,18 @@
           "name": {
             "type": "string",
             "description": "The bank's name.",
-            "example": "Guaranty Trust Bank"
-          }
-        }
-      },
-      "BanksListResults": {
-        "type": "object",
-        "properties": {
-          "results": {
-            "type": "array",
-            "description": "Contains result of all banks fetched",
-            "items": {
-              "$ref": "#/components/schemas/Banks"
-            }
+            "example": "GTBank"
+          },
+          "nipCode": {
+            "type": "string",
+            "nullable": true,
+            "description": "The bank's NIP institution code. May be null.",
+            "example": null
+          },
+          "logo": {
+            "type": "string",
+            "description": "URL of the bank's logo image. An empty string when no logo is available.",
+            "example": "https://firebasestorage.googleapis.com/v0/b/business-banking-93cc1.appspot.com/o/bankLogos%2FGroup%209.png?alt=media&token=98bde9e8-1862-495d-9046-bd3d96465970"
           }
         }
       },


### PR DESCRIPTION
Same fix as kudi-inc/mintlify-docs#20.

`GET /v1/transfers/banks` returns the bank list directly under `data` — there is no `results` wrapper. Verified against the vendor-api source and a live call to `api.nomba.com` (626 banks).

- `nomba-api-reference/openapi.json`: `data` is now a bare array of `Banks`; removed the unused `BanksListResults` schema; added the `nipCode` and `logo` fields the API actually returns, with real example values.
- `docs/products/transfers/fetch-bank-codes-and-names.mdx`: fixed Node.js/Python samples (`data.results` → `data`), replaced the JSON example with the exact live payload, documented `nipCode`/`logo`, and fixed the GTBank lookup example (live `name` is "GTBank").

🤖 Generated with [Claude Code](https://claude.com/claude-code)